### PR TITLE
Automatically update copr_chroots using fedfind

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN dnf -y update && \
         python3-specfile \
         python3-libpagure \
         python3-sentry-sdk \
+        python3-fedfind \
         && \
     dnf clean all
 

--- a/conf/fedora-review-service-prod.yaml
+++ b/conf/fedora-review-service-prod.yaml
@@ -6,10 +6,6 @@ copr_url: "https://copr.fedorainfracloud.org"
 copr_be_url: "https://download.copr.fedorainfracloud.org"
 copr_config: "/persistent/private/.config/copr"
 copr_owner: "@fedora-review"
-copr_chroots:
-  - "fedora-42-x86_64"
-  - "fedora-43-x86_64"
-  - "fedora-rawhide-x86_64"
 
 bugzilla_url: "https://bugzilla.redhat.com"
 bugzilla_config: "/persistent/private/.bugzillarc"

--- a/conf/fedora-review-service-stg.yaml
+++ b/conf/fedora-review-service-stg.yaml
@@ -6,10 +6,6 @@ copr_url: "https://copr.stg.fedoraproject.org"
 copr_be_url: "https://download.copr-dev.fedorainfracloud.org"
 copr_config: "/persistent/private/.config/copr"
 copr_owner: "@fedora-review"
-copr_chroots:
-  - "fedora-42-x86_64"
-  - "fedora-43-x86_64"
-  - "fedora-rawhide-x86_64"
 
 bugzilla_url: "https://bugzilla.stage.redhat.com"
 bugzilla_config: "/persistent/private/.bugzillarc"

--- a/conf/fedora-review-service-tests.yaml
+++ b/conf/fedora-review-service-tests.yaml
@@ -6,10 +6,6 @@ copr_url: "https://copr.fedorainfracloud.org"
 copr_be_url: "https://download.copr.fedorainfracloud.org"
 copr_config: "~/not/existing/config"
 copr_owner: "frostyx"
-copr_chroots:
-  - "fedora-42-x86_64"
-  - "fedora-43-x86_64"
-  - "fedora-rawhide-x86_64"
 
 copr_readonly: false
 bugzilla_readonly: true

--- a/conf/fedora-review-service.yaml
+++ b/conf/fedora-review-service.yaml
@@ -6,10 +6,6 @@ copr_url: "https://copr.fedorainfracloud.org"
 copr_be_url: "https://download.copr.fedorainfracloud.org"
 copr_config: "~/.config/copr"
 copr_owner: "frostyx"
-copr_chroots:
-  - "fedora-42-x86_64"
-  - "fedora-43-x86_64"
-  - "fedora-rawhide-x86_64"
 
 bugzilla_url: "https://bugzilla.redhat.com"
 bugzilla_config: "~/.config/python-bugzilla/.bugzillarc"

--- a/fedora_review_service/logic/copr.py
+++ b/fedora_review_service/logic/copr.py
@@ -1,7 +1,10 @@
 import re
+import traceback
+
 from copr.v3 import Client, CoprRequestException
 from fedora_review_service.config import config
 from fedora_review_service.helpers import remote_diff
+from fedfind.helpers import get_current_stables
 
 
 def create_copr_project_safe(client, owner, project, chroots,
@@ -30,7 +33,7 @@ def submit_to_copr(rhbz, packagename, srpm_url):
     safe_packagename = re.sub(r'[^a-zA-Z0-9_.-]', '_', packagename)
 
     project = "fedora-review-{0}-{1}".format(rhbz, safe_packagename)
-    chroots = config["copr_chroots"]
+    chroots = copr_chroots()
 
     description = (
         "This project contains builds from Fedora Review ticket "
@@ -93,3 +96,20 @@ def copr_spec_url_for_build(build):
         build["id"]
     )
     return "{0}/{1}.spec".format(url, packagename)
+
+def copr_chroots() -> list[str]:
+    copr_chroots = config.get("copr_chroots")
+
+    if not copr_chroots:
+        try:
+            current_stables = get_current_stables()
+        except Exception:
+            # Ideally we'd catch a more specific exception, but the priority here is not falling over if the release.json is irretrievable
+            print("Caught exception whilst trying to load stable Fedora releases. Defaulting to just rawhide.")
+            traceback.print_exc()
+            current_stables = []
+        releases = current_stables + ["rawhide"]
+        copr_chroots = [f"fedora-{r}-x86_64" for r in releases]
+
+    return copr_chroots
+


### PR DESCRIPTION
You can still manually specify chroots if you want, but otherwise it will automatically update when new releases become available.

The library handles caching the results so this shouldn't have a performance impact.
